### PR TITLE
feat(oidc): support private_key_jwt client authentication

### DIFF
--- a/reauth/factors/oauth2/oidc.py
+++ b/reauth/factors/oauth2/oidc.py
@@ -1,6 +1,7 @@
 import abc
 import base64
 import hmac
+import secrets
 import typing
 import urllib.parse
 
@@ -21,6 +22,50 @@ from reauth.logging import get_logger
 from reauth.timestamp import get_current_timestamp
 
 logger = get_logger(__name__)
+
+CLIENT_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+
+
+def build_client_assertion(
+    *,
+    client_id: str,
+    token_endpoint: str,
+    key: str,
+    algorithm: str = "RS256",
+    kid: str | None = None,
+    lifetime: int = 60,
+) -> str:
+    """Build a signed client assertion JWT for `private_key_jwt` authentication.
+
+    Implements the JWT profile for OAuth2 client authentication (RFC 7523): the
+    client proves its identity to the token endpoint with a short-lived JWT signed
+    by its private key, instead of sending a shared secret.
+
+    Args:
+        client_id: The OAuth2 client identifier, used as both `iss` and `sub`.
+        token_endpoint: The token endpoint URL, used as the `aud`.
+        key: The private key to sign with (PEM), as accepted by `jwt.encode`.
+        algorithm: The signing algorithm (e.g. `RS256`, `ES256`).
+        kid: The key ID to advertise in the JWT header, matching the public JWKS.
+        lifetime: The assertion validity in seconds.
+
+    Returns:
+        The signed client assertion JWT.
+    """
+    issued_at = get_current_timestamp()
+    return jwt.encode(
+        {
+            "iss": client_id,
+            "sub": client_id,
+            "aud": token_endpoint,
+            "jti": secrets.token_urlsafe(32),
+            "iat": issued_at,
+            "exp": issued_at + lifetime,
+        },
+        key,
+        algorithm=algorithm,
+        headers={"kid": kid} if kid is not None else None,
+    )
 
 
 class OIDCException(OAuth2Exception):
@@ -331,15 +376,25 @@ class OIDCFactorBase(OAuth2Factor[OIDCExtraParams], abc.ABC):
             "code": code,
             "redirect_uri": redirect_uri,
         }
-        client_secret = await self.get_client_secret()
-        if "client_secret_post" in token_endpoint_auth_methods_supported:
+        client_assertion: str | None = None
+        if "private_key_jwt" in token_endpoint_auth_methods_supported:
+            client_assertion = await self.get_client_assertion(token_endpoint)
+
+        if client_assertion is not None:
             data = {
                 **data,
                 "client_id": self.client_id,
-                "client_secret": client_secret,
+                "client_assertion_type": CLIENT_ASSERTION_TYPE,
+                "client_assertion": client_assertion,
+            }
+        elif "client_secret_post" in token_endpoint_auth_methods_supported:
+            data = {
+                **data,
+                "client_id": self.client_id,
+                "client_secret": await self.get_client_secret(),
             }
         elif "client_secret_basic" in token_endpoint_auth_methods_supported:
-            auth = httpx.BasicAuth(self.client_id, client_secret)
+            auth = httpx.BasicAuth(self.client_id, await self.get_client_secret())
 
         client = self._get_client()
         if code_verifier is not None:
@@ -403,6 +458,21 @@ class OIDCFactorBase(OAuth2Factor[OIDCExtraParams], abc.ABC):
             )
 
         raise OAuth2TokenExchangeException(state=state)
+
+    async def get_client_assertion(self, token_endpoint: str) -> str | None:
+        """Return a signed client assertion JWT for `private_key_jwt` authentication.
+
+        Override to authenticate against the token endpoint with an asymmetric key
+        instead of a shared secret (RFC 7523), e.g. with `build_client_assertion`.
+        Returning `None` (the default) falls back to `client_secret` authentication.
+
+        Args:
+            token_endpoint: The token endpoint URL, used as the assertion audience.
+
+        Returns:
+            The signed client assertion JWT, or `None` to use a client secret.
+        """
+        return None
 
     async def get_id_token_claims(self, id_token: str) -> dict[str, typing.Any]:
         """Decode and return claims from an ID Token JWT.
@@ -566,3 +636,53 @@ class OIDCFactor(OIDCFactorBase):
 
     async def get_client_secret(self) -> str:
         return self._client_secret
+
+
+class PrivateKeyJWTOIDCFactor(OIDCFactorBase):
+    """OpenID Connect factor authenticating with `private_key_jwt` (RFC 7523).
+
+    Signs a short-lived client assertion JWT with the provided private key for
+    each token exchange, instead of sending a shared client secret. The matching
+    public key must be registered with the provider (usually via a JWKS URL).
+
+    The provider must advertise `private_key_jwt` in its
+    `token_endpoint_auth_methods_supported`.
+    """
+
+    def __init__(
+        self,
+        *,
+        identifier: str,
+        client_id: str,
+        signing_key: str,
+        state_service: OAuth2StateService,
+        algorithm: str = "RS256",
+        kid: str | None = None,
+        assertion_lifetime: int = 60,
+        step: int = 0,
+    ) -> None:
+        super().__init__(
+            identifier=identifier,
+            client_id=client_id,
+            state_service=state_service,
+            step=step,
+        )
+        self._signing_key = signing_key
+        self._algorithm = algorithm
+        self._kid = kid
+        self._assertion_lifetime = assertion_lifetime
+
+    async def get_client_secret(self) -> str:
+        raise NotImplementedError(
+            "private_key_jwt authentication does not use a client secret"
+        )
+
+    async def get_client_assertion(self, token_endpoint: str) -> str:
+        return build_client_assertion(
+            client_id=self.client_id,
+            token_endpoint=token_endpoint,
+            key=self._signing_key,
+            algorithm=self._algorithm,
+            kid=self._kid,
+            lifetime=self._assertion_lifetime,
+        )

--- a/tests/factors/oauth2/test_oidc.py
+++ b/tests/factors/oauth2/test_oidc.py
@@ -6,7 +6,7 @@ import urllib.parse
 import httpx
 import jwt
 import pytest
-from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 from sqlalchemy.ext.asyncio import AsyncConnection
@@ -22,10 +22,13 @@ from reauth.factors.oauth2.base import (
     OAuth2TokenUnsupportedGrantTypeException,
 )
 from reauth.factors.oauth2.oidc import (
+    CLIENT_ASSERTION_TYPE,
     DiscoveryDocumentException,
     InvalidIDTokenException,
     JWKSFetchException,
     OIDCFactor,
+    PrivateKeyJWTOIDCFactor,
+    build_client_assertion,
     validate_id_token,
 )
 from reauth.factors.oauth2.state import OAuth2State
@@ -588,3 +591,199 @@ class TestOIDCFactorExchangeCode:
                 redirect_uri="https://example.com/callback",
                 state=oauth2_state,
             )
+
+
+def rsa_key_to_pem(key: RSAPrivateKey) -> str:
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+
+
+class SQLAlchemyPrivateKeyJWTOIDCFactor(PrivateKeyJWTOIDCFactor):
+    """Concrete PrivateKeyJWTOIDCFactor for testing, with a mocked provider."""
+
+    DISCOVERY_ENDPOINT = DISCOVERY_ENDPOINT
+
+    def __init__(
+        self,
+        connection: AsyncConnection,
+        state_service: SQLAlchemyOAuth2StateService,
+        idp_key: RSAPrivateKey,
+        signing_key: RSAPrivateKey,
+    ) -> None:
+        super().__init__(
+            identifier="oidc",
+            client_id="test-client-id",
+            signing_key=rsa_key_to_pem(signing_key),
+            state_service=state_service,
+            kid="signing-key-1",
+        )
+        self.connection = connection
+        self.requests: list[httpx.Request] = []
+        algorithm = jwt.get_algorithm_by_name("RS256")
+        jwk = {
+            **algorithm.to_jwk(idp_key.public_key(), as_dict=True),
+            "kid": "test-key-1",
+        }
+        self.response_map = {
+            DISCOVERY_ENDPOINT: httpx.Response(
+                200,
+                json={
+                    "authorization_endpoint": AUTHORIZATION_ENDPOINT,
+                    "token_endpoint": TOKEN_ENDPOINT,
+                    "jwks_uri": JWKS_URI,
+                    "issuer": ISSUER,
+                    "id_token_signing_alg_values_supported": ["RS256"],
+                    "token_endpoint_auth_methods_supported": ["private_key_jwt"],
+                },
+            ),
+            JWKS_URI: httpx.Response(200, json={"keys": [jwk]}),
+            TOKEN_ENDPOINT: httpx.Response(
+                200,
+                json={
+                    "access_token": "test-access-token",
+                    "expires_in": 3600,
+                    "id_token": create_id_token(
+                        idp_key,
+                        issuer=ISSUER,
+                        audience=self.client_id,
+                        access_token="test-access-token",
+                    ),
+                },
+            ),
+        }
+
+    def _get_client(self) -> httpx.AsyncClient:
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            self.requests.append(request)
+            return self.response_map.get(
+                str(request.url), httpx.Response(404, json={"error": "Not found"})
+            )
+
+        return httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+    async def insert(self, enrollment: OAuth2Enrollment) -> int:
+        raise NotImplementedError()
+
+    async def update(self, enrollment: OAuth2Enrollment) -> None:
+        raise NotImplementedError()
+
+    async def get_enrollment(self, identity_id: int) -> OAuth2Enrollment | None:
+        raise NotImplementedError()
+
+    async def get_enrollment_by_provider_and_account(
+        self, provider: str, account_id: str
+    ) -> OAuth2Enrollment | None:
+        raise NotImplementedError()
+
+
+@pytest.fixture
+def signing_key() -> RSAPrivateKey:
+    return generate_rsa_key()
+
+
+@pytest.fixture
+def private_key_jwt_factor(
+    sqlalchemy_connection: AsyncConnection,
+    oauth2_state_service: SQLAlchemyOAuth2StateService,
+    rsa_key: RSAPrivateKey,
+    signing_key: RSAPrivateKey,
+) -> SQLAlchemyPrivateKeyJWTOIDCFactor:
+    return SQLAlchemyPrivateKeyJWTOIDCFactor(
+        sqlalchemy_connection, oauth2_state_service, rsa_key, signing_key
+    )
+
+
+def parse_token_request(factor: SQLAlchemyPrivateKeyJWTOIDCFactor) -> dict[str, str]:
+    token_request = next(
+        request for request in factor.requests if str(request.url) == TOKEN_ENDPOINT
+    )
+    return dict(urllib.parse.parse_qsl(token_request.content.decode()))
+
+
+class TestBuildClientAssertion:
+    def test_claims_and_header(self, signing_key: RSAPrivateKey) -> None:
+        assertion = build_client_assertion(
+            client_id="test-client-id",
+            token_endpoint=TOKEN_ENDPOINT,
+            key=rsa_key_to_pem(signing_key),
+            kid="signing-key-1",
+        )
+
+        assert jwt.get_unverified_header(assertion)["kid"] == "signing-key-1"
+        claims = jwt.decode(
+            assertion,
+            signing_key.public_key(),
+            algorithms=["RS256"],
+            audience=TOKEN_ENDPOINT,
+        )
+        assert claims["iss"] == "test-client-id"
+        assert claims["sub"] == "test-client-id"
+        assert claims["aud"] == TOKEN_ENDPOINT
+        assert claims["exp"] > claims["iat"]
+        assert "jti" in claims
+
+    def test_unique_jti(self, signing_key: RSAPrivateKey) -> None:
+        pem = rsa_key_to_pem(signing_key)
+        first = build_client_assertion(
+            client_id="c", token_endpoint=TOKEN_ENDPOINT, key=pem
+        )
+        second = build_client_assertion(
+            client_id="c", token_endpoint=TOKEN_ENDPOINT, key=pem
+        )
+        first_jti = jwt.decode(first, options={"verify_signature": False})["jti"]
+        second_jti = jwt.decode(second, options={"verify_signature": False})["jti"]
+        assert first_jti != second_jti
+
+
+@pytest.mark.anyio
+class TestPrivateKeyJWTExchangeCode:
+    """Tests for private_key_jwt client authentication in exchange_code()."""
+
+    async def test_successful_exchange(
+        self,
+        private_key_jwt_factor: SQLAlchemyPrivateKeyJWTOIDCFactor,
+        oauth2_state: OAuth2State,
+    ) -> None:
+        result = await private_key_jwt_factor.exchange_code(
+            code="test-code",
+            redirect_uri="https://example.com/callback",
+            state=oauth2_state,
+        )
+
+        assert result.account_id == "test-user-id"
+        assert result.access_token == "test-access-token"
+
+    async def test_sends_client_assertion_not_secret(
+        self,
+        private_key_jwt_factor: SQLAlchemyPrivateKeyJWTOIDCFactor,
+        signing_key: RSAPrivateKey,
+        oauth2_state: OAuth2State,
+    ) -> None:
+        await private_key_jwt_factor.exchange_code(
+            code="test-code",
+            redirect_uri="https://example.com/callback",
+            state=oauth2_state,
+        )
+
+        body = parse_token_request(private_key_jwt_factor)
+        assert body["client_id"] == "test-client-id"
+        assert body["client_assertion_type"] == CLIENT_ASSERTION_TYPE
+        assert "client_secret" not in body
+
+        claims = jwt.decode(
+            body["client_assertion"],
+            signing_key.public_key(),
+            algorithms=["RS256"],
+            audience=TOKEN_ENDPOINT,
+        )
+        assert claims["iss"] == "test-client-id"
+        assert claims["sub"] == "test-client-id"
+
+    async def test_get_client_secret_not_supported(
+        self, private_key_jwt_factor: SQLAlchemyPrivateKeyJWTOIDCFactor
+    ) -> None:
+        with pytest.raises(NotImplementedError):
+            await private_key_jwt_factor.get_client_secret()


### PR DESCRIPTION
## What

Add support for `private_key_jwt` client authentication (RFC 7523) in the OIDC token exchange, alongside the existing `client_secret_basic` / `client_secret_post`.

- `get_client_assertion()` hook on `OIDCFactorBase` — defaults to `None`, so existing factors are unchanged.
- `exchange_code` uses a signed client assertion when the provider advertises `private_key_jwt`, else falls back to the client secret.
- `build_client_assertion()` helper + a turnkey `PrivateKeyJWTOIDCFactor` (PEM signing key), mirroring the JWT signing already used by `AppleOAuth2Factor`.

## Why

Asymmetric client auth is required by IdPs like Okta and avoids storing a shared secret. The public key is registered with the provider via JWKS.

## Notes

- Fully additive / non-breaking — the `None`-default hook keeps current behavior identical.
- Tests cover assertion claims/header, unique `jti`, a full exchange asserting `client_assertion` is sent (and no `client_secret`).
- Possibly worth reflecting under "Social Login" in the roadmap — leaving that to you.