### PR TITLE
refactor(oauth2): agnostic client authentication via get_request_authentication

### DIFF
--- a/reauth/factors/oauth2/apple.py
+++ b/reauth/factors/oauth2/apple.py
@@ -72,15 +72,16 @@ class AppleOAuth2Factor(OIDCFactorBase, abc.ABC):
             extra=extra,
         )
 
-    async def get_client_secret(self) -> str:
-        """Generate a JWT client secret for Apple's OAuth2 token exchange.
+    async def get_request_authentication(
+        self, *, token_endpoint: str
+    ) -> tuple[dict[str, str], dict[str, str]]:
+        """Authenticate with a per-request JWT client secret (Apple Sign In).
 
-        Creates a signed JWT containing the team ID, client ID, and expiration time.
-        The JWT is signed with the ES256 algorithm using the private key provided
-        during initialization.
+        Apple requires a short-lived ES256-signed JWT as the client secret,
+        sent as a `client_secret_post` body parameter.
 
         Returns:
-            A JWT string to be used as the client secret.
+            A tuple of (no extra headers, body with the client_id and JWT secret).
         """
         iat = int(time.time())
         client_secret = jwt.encode(
@@ -97,7 +98,7 @@ class AppleOAuth2Factor(OIDCFactorBase, abc.ABC):
                 "kid": self.key_id,
             },
         )
-        return client_secret
+        return {}, {"client_id": self.client_id, "client_secret": client_secret}
 
     async def get_profile(self, access_token: str) -> dict[str, typing.Any]:
         """Apple does not support userinfo endpoint.

--- a/reauth/factors/oauth2/base.py
+++ b/reauth/factors/oauth2/base.py
@@ -542,17 +542,24 @@ class OAuth2Factor[EXTRA](FactorBase[OAuth2Enrollment], abc.ABC):
         return enrollment
 
     @abc.abstractmethod
-    async def get_client_secret(self) -> str:
-        """Get the client secret for token exchange.
+    async def get_request_authentication(
+        self, *, token_endpoint: str
+    ) -> tuple[dict[str, str], dict[str, str]]:
+        """Authenticate the client for the token request (RFC 6749 Section 4.1.3).
 
-        This method retrieves the client secret used for client authentication
-        during the OAuth 2.0 token exchange (RFC 6749 Section 4.1.3).
-        Implementations may return a static secret, fetch it from a secure vault,
-        or generate it dynamically (e.g., for providers like Apple that require
-        JWT-based client secrets).
+        Returns the extra headers and body parameters that prove the client's
+        identity to the token endpoint, letting each provider authenticate by
+        header (e.g. ``client_secret_basic``) or body (e.g. ``client_secret_post``,
+        ``private_key_jwt``) without the flow knowing the strategy. Both are
+        merged into the token request.
+
+        Args:
+            token_endpoint: The token endpoint URL the request targets, for
+                strategies that bind authentication to it (e.g. the
+                ``private_key_jwt`` assertion audience).
 
         Returns:
-            The client secret string.
+            A tuple ``(headers, body)`` of extra request headers and body params.
         """
         ...
 
@@ -600,8 +607,9 @@ class OAuth2Factor[EXTRA](FactorBase[OAuth2Enrollment], abc.ABC):
         """Exchange authorization code for access token (RFC 6749 Section 4.1.3).
 
         Provider-specific implementations should call their token endpoint
-        and return the token response data. Use self.client_id and get_client_secret()
-        for client authentication as required by the provider.
+        and return the token response data. Use self.client_id and
+        get_request_authentication() for client authentication as required by
+        the provider.
 
         Args:
             code: The authorization code from the callback.

--- a/reauth/factors/oauth2/github.py
+++ b/reauth/factors/oauth2/github.py
@@ -98,8 +98,10 @@ class GitHubOAuth2Factor(OAuth2Factor[GitHubOAuth2Extra], abc.ABC):
         self._client_secret = client_secret
         self._client = httpx.AsyncClient()
 
-    async def get_client_secret(self) -> str:
-        return self._client_secret
+    async def get_request_authentication(
+        self, *, token_endpoint: str
+    ) -> tuple[dict[str, str], dict[str, str]]:
+        return {}, {"client_id": self.client_id, "client_secret": self._client_secret}
 
     async def get_authorization_url(
         self,
@@ -148,13 +150,14 @@ class GitHubOAuth2Factor(OAuth2Factor[GitHubOAuth2Extra], abc.ABC):
         state: OAuth2State,
     ) -> TokenResponse:
         logger.debug("GitHub exchange_code called", extra={"provider": self.identifier})
-        client_secret = await self.get_client_secret()
+        headers, auth_body = await self.get_request_authentication(
+            token_endpoint=self.TOKEN_ENDPOINT
+        )
         data = {
             "grant_type": "authorization_code",
             "code": code,
             "redirect_uri": redirect_uri,
-            "client_id": self.client_id,
-            "client_secret": client_secret,
+            **auth_body,
         }
         if code_verifier is not None:
             data["code_verifier"] = code_verifier
@@ -163,7 +166,7 @@ class GitHubOAuth2Factor(OAuth2Factor[GitHubOAuth2Extra], abc.ABC):
         try:
             response = await client.post(
                 self.TOKEN_ENDPOINT,
-                headers={"Accept": "application/json"},
+                headers={"Accept": "application/json", **headers},
                 data=data,
             )
         except httpx.RequestError as e:

--- a/reauth/factors/oauth2/oidc.py
+++ b/reauth/factors/oauth2/oidc.py
@@ -236,10 +236,9 @@ class OIDCFactorBase(OAuth2Factor[OIDCExtraParams], abc.ABC):
     This class implements the core OIDC flow using the discovery document
     and JWKS for ID Token validation.
 
-    Subclasses must implement `get_client_secret()` to provide the client secret
-    for token exchange. For cases where the client secret is static and known
-    at instantiation, use the `OIDCFactor` subclass which provides a default
-    implementation.
+    Subclasses must implement `get_request_authentication()` to authenticate the
+    token request. For the common static `client_secret` case, use the
+    `OIDCFactor` subclass, which handles `client_secret_basic`/`client_secret_post`.
 
     References:
         - OpenID Connect Core 1.0: https://openid.net/specs/openid-connect-core-1_0.html
@@ -321,35 +320,26 @@ class OIDCFactorBase(OAuth2Factor[OIDCExtraParams], abc.ABC):
         logger.debug("OIDC exchange_code called", extra={"provider": self.identifier})
         discovery_document = await self._get_discovery_document()
         token_endpoint = discovery_document["token_endpoint"]
-        token_endpoint_auth_methods_supported = discovery_document.get(
-            "token_endpoint_auth_methods_supported", ["client_secret_basic"]
-        )
 
-        auth: httpx.BasicAuth | None = None
         data = {
             "grant_type": "authorization_code",
             "code": code,
             "redirect_uri": redirect_uri,
         }
-        client_secret = await self.get_client_secret()
-        if "client_secret_post" in token_endpoint_auth_methods_supported:
-            data = {
-                **data,
-                "client_id": self.client_id,
-                "client_secret": client_secret,
-            }
-        elif "client_secret_basic" in token_endpoint_auth_methods_supported:
-            auth = httpx.BasicAuth(self.client_id, client_secret)
-
-        client = self._get_client()
         if code_verifier is not None:
             data["code_verifier"] = code_verifier
 
+        headers, auth_body = await self.get_request_authentication(
+            token_endpoint=token_endpoint
+        )
+        data = {**data, **auth_body}
+
+        client = self._get_client()
         try:
             response = await client.post(
                 token_endpoint,
                 data=data,
-                auth=auth if auth else httpx.USE_CLIENT_DEFAULT,
+                headers=headers or None,
             )
         except httpx.RequestError as e:
             raise OAuth2TokenExchangeException(state=state) from e
@@ -540,11 +530,12 @@ class OIDCFactorBase(OAuth2Factor[OIDCExtraParams], abc.ABC):
 class OIDCFactor(OIDCFactorBase):
     """OpenID Connect factor implementation with a static client secret.
 
-    This class provides a default implementation of `get_client_secret()` that returns
-    a fixed client secret provided at instantiation. Use this for most OAuth providers.
+    Authenticates with a fixed client secret provided at instantiation, using
+    `client_secret_post` or `client_secret_basic` depending on what the provider
+    advertises in its discovery document. Use this for most OAuth providers.
 
-    For providers requiring dynamic client secrets (e.g., Apple Sign In),
-    subclass `OIDCFactorBase` directly and override `get_client_secret()`.
+    For providers requiring dynamic credentials (e.g., Apple Sign In), subclass
+    `OIDCFactorBase` directly and override `get_request_authentication()`.
     """
 
     def __init__(
@@ -564,5 +555,19 @@ class OIDCFactor(OIDCFactorBase):
         )
         self._client_secret = client_secret
 
-    async def get_client_secret(self) -> str:
-        return self._client_secret
+    async def get_request_authentication(
+        self, *, token_endpoint: str
+    ) -> tuple[dict[str, str], dict[str, str]]:
+        discovery_document = await self._get_discovery_document()
+        auth_methods = discovery_document.get(
+            "token_endpoint_auth_methods_supported", ["client_secret_basic"]
+        )
+        if "client_secret_post" in auth_methods:
+            return {}, {
+                "client_id": self.client_id,
+                "client_secret": self._client_secret,
+            }
+        credentials = base64.b64encode(
+            f"{self.client_id}:{self._client_secret}".encode()
+        ).decode()
+        return {"Authorization": f"Basic {credentials}"}, {}

--- a/tests/factors/oauth2/test_apple.py
+++ b/tests/factors/oauth2/test_apple.py
@@ -1,0 +1,62 @@
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from reauth.factors.oauth2.apple import AppleOAuth2Factor
+from reauth.factors.oauth2.base import OAuth2Enrollment
+
+from .conftest import SQLAlchemyOAuth2StateService
+
+
+def _generate_ec_key() -> str:
+    key = ec.generate_private_key(ec.SECP256R1())
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+
+
+class _AppleFactor(AppleOAuth2Factor):
+    async def insert(self, enrollment: OAuth2Enrollment) -> int:
+        raise NotImplementedError()
+
+    async def update(self, enrollment: OAuth2Enrollment) -> None:
+        raise NotImplementedError()
+
+    async def get_enrollment_by_provider_and_account(
+        self, provider: str, account_id: str
+    ) -> OAuth2Enrollment | None:
+        raise NotImplementedError()
+
+    async def get_enrollment(self, identity_id: int) -> OAuth2Enrollment | None:
+        raise NotImplementedError()
+
+
+@pytest.mark.anyio
+class TestAppleFactorGetRequestAuthentication:
+    """Tests for AppleOAuth2Factor.get_request_authentication()."""
+
+    async def test_returns_signed_jwt_client_secret(
+        self, oauth2_state_service: SQLAlchemyOAuth2StateService
+    ) -> None:
+        """Apple authenticates with a per-request ES256 JWT in the request body."""
+        factor = _AppleFactor(
+            client_id="com.example.app",
+            team_id="TEAM123456",
+            key_id="KEY123456",
+            key_value=_generate_ec_key(),
+            state_service=oauth2_state_service,
+        )
+
+        headers, body = await factor.get_request_authentication(
+            token_endpoint="https://appleid.apple.com/auth/token"
+        )
+
+        assert headers == {}
+        assert body["client_id"] == "com.example.app"
+        claims = jwt.decode(body["client_secret"], options={"verify_signature": False})
+        assert claims["iss"] == "TEAM123456"
+        assert claims["sub"] == "com.example.app"
+        assert claims["aud"] == "https://appleid.apple.com"

--- a/tests/factors/oauth2/test_base.py
+++ b/tests/factors/oauth2/test_base.py
@@ -51,9 +51,11 @@ class SQLAlchemyOAuth2Factor(OAuth2Factor):
             return None
         return OAuth2Enrollment(**row._asdict())
 
-    async def get_client_secret(self) -> str:
-        """Return a dummy client secret for testing purposes."""
-        return "test-client-secret"
+    async def get_request_authentication(
+        self, *, token_endpoint: str
+    ) -> tuple[dict[str, str], dict[str, str]]:
+        """Return dummy client authentication for testing purposes."""
+        return {}, {"client_id": self.client_id, "client_secret": "test-client-secret"}
 
     async def get_authorization_url(
         self,

--- a/tests/factors/oauth2/test_github.py
+++ b/tests/factors/oauth2/test_github.py
@@ -1,0 +1,47 @@
+import pytest
+
+from reauth.factors.oauth2.base import OAuth2Enrollment
+from reauth.factors.oauth2.github import GitHubOAuth2Factor
+
+from .conftest import SQLAlchemyOAuth2StateService
+
+
+class _GitHubFactor(GitHubOAuth2Factor):
+    async def insert(self, enrollment: OAuth2Enrollment) -> int:
+        raise NotImplementedError()
+
+    async def update(self, enrollment: OAuth2Enrollment) -> None:
+        raise NotImplementedError()
+
+    async def get_enrollment_by_provider_and_account(
+        self, provider: str, account_id: str
+    ) -> OAuth2Enrollment | None:
+        raise NotImplementedError()
+
+    async def get_enrollment(self, identity_id: int) -> OAuth2Enrollment | None:
+        raise NotImplementedError()
+
+
+@pytest.mark.anyio
+class TestGitHubFactorGetRequestAuthentication:
+    """Tests for GitHubOAuth2Factor.get_request_authentication()."""
+
+    async def test_returns_credentials_in_body(
+        self, oauth2_state_service: SQLAlchemyOAuth2StateService
+    ) -> None:
+        """GitHub authenticates with client_id/client_secret in the request body."""
+        factor = _GitHubFactor(
+            client_id="github-client-id",
+            client_secret="github-client-secret",
+            state_service=oauth2_state_service,
+        )
+
+        headers, body = await factor.get_request_authentication(
+            token_endpoint=GitHubOAuth2Factor.TOKEN_ENDPOINT
+        )
+
+        assert headers == {}
+        assert body == {
+            "client_id": "github-client-id",
+            "client_secret": "github-client-secret",
+        }

--- a/tests/factors/oauth2/test_oidc.py
+++ b/tests/factors/oauth2/test_oidc.py
@@ -498,6 +498,57 @@ class TestOIDCFactorGetAuthorizationURL:
 
 
 @pytest.mark.anyio
+class TestOIDCFactorGetRequestAuthentication:
+    """Tests for OIDCFactor.get_request_authentication()."""
+
+    async def test_client_secret_post(
+        self,
+        sqlalchemy_connection: AsyncConnection,
+        oauth2_state_service: SQLAlchemyOAuth2StateService,
+        rsa_key: RSAPrivateKey,
+    ) -> None:
+        """client_secret_post returns the credentials in the request body."""
+        factor = SQLAlchemyOIDCFactor(
+            sqlalchemy_connection,
+            oauth2_state_service,
+            rsa_key,
+            ["client_secret_post"],
+        )
+
+        headers, body = await factor.get_request_authentication(
+            token_endpoint=TOKEN_ENDPOINT
+        )
+
+        assert headers == {}
+        assert body == {
+            "client_id": "test-client-id",
+            "client_secret": "test-client-secret",
+        }
+
+    async def test_client_secret_basic(
+        self,
+        sqlalchemy_connection: AsyncConnection,
+        oauth2_state_service: SQLAlchemyOAuth2StateService,
+        rsa_key: RSAPrivateKey,
+    ) -> None:
+        """client_secret_basic returns the credentials in an Authorization header."""
+        factor = SQLAlchemyOIDCFactor(
+            sqlalchemy_connection,
+            oauth2_state_service,
+            rsa_key,
+            ["client_secret_basic"],
+        )
+
+        headers, body = await factor.get_request_authentication(
+            token_endpoint=TOKEN_ENDPOINT
+        )
+
+        expected = base64.b64encode(b"test-client-id:test-client-secret").decode()
+        assert headers == {"Authorization": f"Basic {expected}"}
+        assert body == {}
+
+
+@pytest.mark.anyio
 class TestOIDCFactorExchangeCode:
     """Tests for OIDCFactor.exchange_code()."""
 


### PR DESCRIPTION
## What

Replaces the abstract `get_client_secret()` on `OAuth2Factor` with:

```python
async def get_request_authentication(self, *, token_endpoint: str) -> tuple[dict[str, str], dict[str, str]]:  # (extra headers, extra body params)
```

Both the returned headers and body params are merged into the token-endpoint request, so a factor can authenticate by header (client_secret_basic) or body (client_secret_post) without exchange_code knowing the strategy.