### PR TITLE
feat(oidc): add private_key_jwt client authentication

### DIFF
--- a/.agents/skills/rfc7523/SKILL.md
+++ b/.agents/skills/rfc7523/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: rfc7523
+description: "RFC 7523: JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants. Profiles the OAuth Assertion Framework (RFC 7521) to define (1) the jwt-bearer authorization grant for requesting an access token from an existing trust relationship without a user-approval step, and (2) JWT-based client authentication at the token endpoint via client_assertion. The basis for the private_key_jwt client authentication method. Use when implementing or validating signed JWT assertions for OAuth token requests, client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer, or iss/sub/aud/exp claim validation."
+---
+
+# RFC 7523: JWT Profile for OAuth 2.0 Client Authentication and Authorization Grants
+
+**Category:** Standards Track
+**Published:** May 2015
+**Authors:** M. Jones (Microsoft), B. Campbell (Ping Identity), C. Mortimore (Salesforce)
+**Profiles:** RFC 7521 (OAuth Assertion Framework)
+**Related to:** RFC 6749 (OAuth 2.0), RFC 7519 (JWT), RFC 7522 (SAML 2.0 Profile)
+
+This specification profiles the abstract **OAuth Assertion Framework** (RFC 7521) for **JSON Web Tokens**, defining two orthogonal and separable uses of a signed JWT in an OAuth 2.0 access-token request:
+
+1. **JWT as an authorization grant** — request an access token using an existing trust relationship expressed by the JWT, without a direct user-approval step.
+2. **JWT for client authentication** — authenticate the client to the token endpoint as an alternative to a shared `client_secret`.
+
+These two uses can be combined or used separately. Client authentication via JWT is "nothing more than an alternative way for a client to authenticate to the token endpoint" and must accompany some grant type to form a complete request.
+
+> **Why this skill matters for reauth:** the `private_key_jwt` client authentication method (OpenID Connect Core `token_endpoint_auth_method`) is RFC 7523 §2.2 client authentication, with the assertion signed asymmetrically. This RFC is the authoritative source for the `client_assertion` / `client_assertion_type` parameters and the JWT claim-validation rules that an authorization server enforces.
+
+## When to Use This Skill
+
+Use this skill when working with:
+- `private_key_jwt` client authentication (OIDC) and its claim construction/validation
+- The `client_assertion` and `client_assertion_type` token-endpoint parameters
+- The `urn:ietf:params:oauth:grant-type:jwt-bearer` authorization grant
+- Building or validating signed JWT assertions for OAuth token requests
+- `iss` / `sub` / `aud` / `exp` / `nbf` / `iat` / `jti` claim semantics for assertions
+- Replay protection (`jti`) for OAuth assertions
+- Distinguishing JWT-as-grant from JWT-as-client-authentication
+
+## Two Independent Mechanisms
+
+| | Authorization Grant (§2.1) | Client Authentication (§2.2) |
+|---|---|---|
+| **Purpose** | Obtain an access token from a trust relationship | Authenticate the client at the token endpoint |
+| **Parameter carrying the JWT** | `assertion` | `client_assertion` |
+| **Selecting parameter** | `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer` | `client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer` |
+| **`sub` claim** | The authorized accessor (resource owner / delegate; may be pseudonymous) | MUST be the `client_id` of the OAuth client |
+| **Error on invalid JWT** | `invalid_grant` | `invalid_client` |
+| **Combined with a grant?** | It *is* the grant | Yes — accompanies another `grant_type` (e.g. `authorization_code`, `client_credentials`) |
+
+## §2.1 — Using a JWT as an Authorization Grant
+
+```
+POST /token.oauth2 HTTP/1.1
+Host: as.example.com
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer
+&assertion=eyJhbGciOiJFUzI1NiIsImtpZCI6IjE2In0.eyJpc3Mi...[JWT]
+```
+
+- `grant_type` MUST be `urn:ietf:params:oauth:grant-type:jwt-bearer`.
+- `assertion` MUST contain a **single** JWT.
+- `scope` MAY be used to request scope.
+- Client authentication is **optional** here; `client_id` is only needed when a client-authentication method that relies on it is used.
+
+## §2.2 — Using a JWT for Client Authentication (the `private_key_jwt` path)
+
+```
+POST /token.oauth2 HTTP/1.1
+Host: as.example.com
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=authorization_code
+&code=n0esc3NRze7LTCu7iYzS6a5acc3f0ogp4
+&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer
+&client_assertion=eyJhbGciOiJSUzI1NiIsImtpZCI6IjIyIn0.eyJpc3Mi...[JWT]
+```
+
+- `client_assertion_type` MUST be `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`.
+- `client_assertion` contains a **single** JWT; it MUST NOT contain more than one.
+- The assertion accompanies a normal grant request (`authorization_code`, `client_credentials`, etc.).
+- For `private_key_jwt`, the JWT is signed with the client's private key; the AS verifies with the client's registered public key (e.g. via `jwks` / `jwks_uri`).
+
+## §3 — JWT Format and Processing Requirements (AS validation)
+
+The authorization server **MUST** validate the JWT against all of the following:
+
+| # | Claim | Requirement |
+|---|-------|-------------|
+| 1 | `iss` | **MUST** be present; unique identifier of the issuer. Compare with **Simple String Comparison** (RFC 3986 §6.2.1) absent a profile saying otherwise. |
+| 2 | `sub` | **MUST** be present. For a grant: the authorized accessor (may be pseudonymous). For **client authentication: MUST be the `client_id`**. |
+| 3 | `aud` | **MUST** be present and identify the AS. The token-endpoint URL MAY be used. AS **MUST reject** any JWT that does not list its own identity as audience. Simple String Comparison. |
+| 4 | `exp` | **MUST** be present. AS **MUST reject** expired JWTs (subject to allowable clock skew). MAY reject `exp` unreasonably far in the future. |
+| 5 | `nbf` | MAY be present; if so, token MUST NOT be accepted before this time. |
+| 6 | `iat` | MAY be present. AS MAY reject `iat` unreasonably far in the past. |
+| 7 | `jti` | MAY be present. AS **MAY enforce replay protection** by tracking used `jti` values for the JWT's validity window. |
+| 8 | other | The JWT MAY contain other claims. |
+| 9 | signature | The JWT **MUST** be digitally signed or MAC'd by the issuer. AS **MUST reject** invalid signatures/MACs. |
+| 10 | JWT validity | AS **MUST reject** a JWT invalid in any other respect per RFC 7519 (JWT). |
+
+### Error responses
+
+| Context | `error` code |
+|---------|--------------|
+| Invalid JWT used as **authorization grant** (§3.1) | `invalid_grant` |
+| Invalid JWT used for **client authentication** (§3.2) | `invalid_client` |
+
+```
+HTTP/1.1 400 Bad Request
+Content-Type: application/json
+Cache-Control: no-store
+
+{ "error": "invalid_grant", "error_description": "Audience validation failed" }
+```
+
+If client credentials are present alongside a JWT grant, the AS MUST validate them.
+
+## §4 — Example JWT Claims Set
+
+```json
+{
+  "iss": "https://jwt-idp.example.com",
+  "sub": "mailto:mike@example.com",
+  "aud": "https://jwt-rp.example.net",
+  "nbf": 1300815780,
+  "exp": 1300819380,
+  "http://claims.example.com/member": true
+}
+```
+
+Header (ECDSA P-256 / SHA-256, key id `16`):
+
+```json
+{ "alg": "ES256", "kid": "16" }
+```
+
+## §6 — Security Considerations
+
+- All security considerations of RFC 7521, RFC 6749, and RFC 7519 (JWT) apply.
+- **Replay protection is NOT mandated** for either use — it is an optional feature (see `jti`, claim 7) that implementations MAY employ at their discretion.
+
+## §7 — Privacy Considerations
+
+- A JWT may carry privacy-sensitive data; transmit only over encrypted channels (TLS), or encrypt the JWT to the AS.
+- Include only the minimum claims necessary; `sub` MAY be an anonymous/pseudonymous value.
+
+## §8 — IANA Registrations (OAuth URI registry)
+
+| URN | Use |
+|-----|-----|
+| `urn:ietf:params:oauth:grant-type:jwt-bearer` | JWT Bearer authorization grant type |
+| `urn:ietf:params:oauth:client-assertion-type:jwt-bearer` | JWT Bearer client authentication assertion type |
+
+## Quick Reference
+
+| Section | Title |
+|---------|-------|
+| 1 | Introduction |
+| 1.2 | Terminology |
+| 2 | HTTP Parameter Bindings for Transporting Assertions |
+| 2.1 | Using JWTs as Authorization Grants |
+| 2.2 | Using JWTs for Client Authentication |
+| 3 | JWT Format and Processing Requirements |
+| 3.1 | Authorization Grant Processing |
+| 3.2 | Client Authentication Processing |
+| 4 | Authorization Grant Example |
+| 5 | Interoperability Considerations |
+| 6 | Security Considerations |
+| 7 | Privacy Considerations |
+| 8 | IANA Considerations |
+
+## Implementation Checklist (client authentication / `private_key_jwt`)
+
+- [ ] Set `client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer`
+- [ ] Send exactly one JWT in `client_assertion`
+- [ ] Set `iss` = `sub` = `client_id`
+- [ ] Set `aud` to the AS token endpoint (or AS-published identifier)
+- [ ] Include a short-lived `exp` (and consider `nbf` / `iat`)
+- [ ] Include a unique `jti` if the AS enforces replay protection
+- [ ] Sign the JWT (asymmetric key for `private_key_jwt`); ensure the AS can resolve the verification key (`kid` / `jwks`)
+- [ ] On the AS side, reject on bad `aud`, expired `exp`, bad signature → `invalid_client`
+
+## Related RFCs
+
+- **RFC 7521**: Assertion Framework for OAuth 2.0 (the abstract framework this profiles)
+- **RFC 6749**: The OAuth 2.0 Authorization Framework
+- **RFC 7519**: JSON Web Token (JWT)
+- **RFC 7522**: SAML 2.0 Profile for OAuth 2.0 (sibling profile)
+- **RFC 6755**: An IETF URN Sub-Namespace for OAuth
+- **OpenID Connect Core**: defines `private_key_jwt` / `client_secret_jwt` `token_endpoint_auth_method` values built on this profile
+
+## Full RFC Text
+
+See [references/RFC7523.txt](references/RFC7523.txt) for the complete document.

--- a/.agents/skills/rfc7523/references/RFC7523.txt
+++ b/.agents/skills/rfc7523/references/RFC7523.txt
@@ -1,0 +1,675 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                          M. Jones
+Request for Comments: 7523                                     Microsoft
+Category: Standards Track                                    B. Campbell
+ISSN: 2070-1721                                            Ping Identity
+                                                            C. Mortimore
+                                                              Salesforce
+                                                                May 2015
+
+
+                      JSON Web Token (JWT) Profile
+      for OAuth 2.0 Client Authentication and Authorization Grants
+
+Abstract
+
+   This specification defines the use of a JSON Web Token (JWT) Bearer
+   Token as a means for requesting an OAuth 2.0 access token as well as
+   for client authentication.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc7523.
+
+Copyright Notice
+
+   Copyright (c) 2015 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+Jones, et al.                Standards Track                    [Page 1]
+
+RFC 7523              OAuth JWT Assertion Profiles              May 2015
+
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
+     1.1.  Notational Conventions  . . . . . . . . . . . . . . . . .   4
+     1.2.  Terminology . . . . . . . . . . . . . . . . . . . . . . .   4
+   2.  HTTP Parameter Bindings for Transporting Assertions . . . . .   4
+     2.1.  Using JWTs as Authorization Grants  . . . . . . . . . . .   4
+     2.2.  Using JWTs for Client Authentication  . . . . . . . . . .   5
+   3.  JWT Format and Processing Requirements  . . . . . . . . . . .   5
+     3.1.  Authorization Grant Processing  . . . . . . . . . . . . .   7
+     3.2.  Client Authentication Processing  . . . . . . . . . . . .   8
+   4.  Authorization Grant Example . . . . . . . . . . . . . . . . .   8
+   5.  Interoperability Considerations . . . . . . . . . . . . . . .   9
+   6.  Security Considerations . . . . . . . . . . . . . . . . . . .   9
+   7.  Privacy Considerations  . . . . . . . . . . . . . . . . . . .  10
+   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  10
+     8.1.  Sub-Namespace Registration of
+           urn:ietf:params:oauth:grant-type:jwt-bearer . . . . . . .  10
+     8.2.  Sub-Namespace Registration of
+           urn:ietf:params:oauth:client-assertion-type:jwt-bearer  .  10
+   9.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  11
+     9.1.  Normative References  . . . . . . . . . . . . . . . . . .  11
+     9.2.  Informative References  . . . . . . . . . . . . . . . . .  11
+   Acknowledgements  . . . . . . . . . . . . . . . . . . . . . . . .  12
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  12
+
+1.  Introduction
+
+   JSON Web Token (JWT) [JWT] is a JSON-based [RFC7159] security token
+   encoding that enables identity and security information to be shared
+   across security domains.  A security token is generally issued by an
+   Identity Provider and consumed by a Relying Party that relies on its
+   content to identify the token's subject for security-related
+   purposes.
+
+   The OAuth 2.0 Authorization Framework [RFC6749] provides a method for
+   making authenticated HTTP requests to a resource using an access
+   token.  Access tokens are issued to third-party clients by an
+   authorization server (AS) with the (sometimes implicit) approval of
+   the resource owner.  In OAuth, an authorization grant is an abstract
+   term used to describe intermediate credentials that represent the
+   resource owner authorization.  An authorization grant is used by the
+   client to obtain an access token.  Several authorization grant types
+   are defined to support a wide range of client types and user
+   experiences.  OAuth also allows for the definition of new extension
+   grant types to support additional clients or to provide a bridge
+   between OAuth and other trust frameworks.  Finally, OAuth allows the
+
+
+
+
+Jones, et al.                Standards Track                    [Page 2]
+
+RFC 7523              OAuth JWT Assertion Profiles              May 2015
+
+
+   definition of additional authentication mechanisms to be used by
+   clients when interacting with the authorization server.
+
+   "Assertion Framework for OAuth 2.0 Client Authentication and
+   Authorization Grants" [RFC7521] is an abstract extension to OAuth 2.0
+   that provides a general framework for the use of assertions (a.k.a.
+   security tokens) as client credentials and/or authorization grants
+   with OAuth 2.0.  This specification profiles the OAuth Assertion
+   Framework [RFC7521] to define an extension grant type that uses a JWT
+   Bearer Token to request an OAuth 2.0 access token as well as for use
+   as client credentials.  The format and processing rules for the JWT
+   defined in this specification are intentionally similar, though not
+   identical, to those in the closely related specification "Security
+   Assertion Markup Language (SAML) 2.0 Profile for OAuth 2.0 Client
+   Authentication and Authorization Grants" [RFC7522].  The differences
+   arise where the structure and semantics of JWTs differ from SAML
+   Assertions.  JWTs, for example, have no direct equivalent to the
+   <SubjectConfirmation> or <AuthnStatement> elements of SAML
+   Assertions.
+
+   This document defines how a JWT Bearer Token can be used to request
+   an access token when a client wishes to utilize an existing trust
+   relationship, expressed through the semantics of the JWT, without a
+   direct user-approval step at the authorization server.  It also
+   defines how a JWT can be used as a client authentication mechanism.
+   The use of a security token for client authentication is orthogonal
+   to and separable from using a security token as an authorization
+   grant.  They can be used either in combination or separately.  Client
+   authentication using a JWT is nothing more than an alternative way
+   for a client to authenticate to the token endpoint and must be used
+   in conjunction with some grant type to form a complete and meaningful
+   protocol request.  JWT authorization grants may be used with or
+   without client authentication or identification.  Whether or not
+   client authentication is needed in conjunction with a JWT
+   authorization grant, as well as the supported types of client
+   authentication, are policy decisions at the discretion of the
+   authorization server.
+
+   The process by which the client obtains the JWT, prior to exchanging
+   it with the authorization server or using it for client
+   authentication, is out of scope.
+
+
+
+
+
+
+
+
+
+
+Jones, et al.                Standards Track                    [Page 3]
+
+RFC 7523              OAuth JWT Assertion Profiles              May 2015
+
+
+1.1.  Notational Conventions
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+   Unless otherwise noted, all the protocol parameter names and values
+   are case sensitive.
+
+1.2.  Terminology
+
+   All terms are as defined in the following specifications: "The OAuth
+   2.0 Authorization Framework" [RFC6749], the OAuth Assertion Framework
+   [RFC7521], and "JSON Web Token (JWT)" [JWT].
+
+2.  HTTP Parameter Bindings for Transporting Assertions
+
+   The OAuth Assertion Framework [RFC7521] defines generic HTTP
+   parameters for transporting assertions (a.k.a. security tokens)
+   during interactions with a token endpoint.  This section defines
+   specific parameters and treatments of those parameters for use with
+   JWT Bearer Tokens.
+
+2.1.  Using JWTs as Authorization Grants
+
+   To use a Bearer JWT as an authorization grant, the client uses an
+   access token request as defined in Section 4 of the OAuth Assertion
+   Framework [RFC7521] with the following specific parameter values and
+   encodings.
+
+   The value of the "grant_type" is "urn:ietf:params:oauth:grant-
+   type:jwt-bearer".
+
+   The value of the "assertion" parameter MUST contain a single JWT.
+
+   The "scope" parameter may be used, as defined in the OAuth Assertion
+   Framework [RFC7521], to indicate the requested scope.
+
+   Authentication of the client is optional, as described in
+   Section 3.2.1 of OAuth 2.0 [RFC6749] and consequently, the
+   "client_id" is only needed when a form of client authentication that
+   relies on the parameter is used.
+
+
+
+
+
+
+
+
+
+Jones, et al.                Standards Track                    [Page 4]
+
+RFC 7523              OAuth JWT Assertion Profiles              May 2015
+
+
+   The following example demonstrates an access token request with a JWT
+   as an authorization grant (with extra line breaks for display
+   purposes only):
+
+     POST /token.oauth2 HTTP/1.1
+     Host: as.example.com
+     Content-Type: application/x-www-form-urlencoded
+
+     grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer
+     &assertion=eyJhbGciOiJFUzI1NiIsImtpZCI6IjE2In0.
+     eyJpc3Mi[...omitted for brevity...].
+     J9l-ZhwP[...omitted for brevity...]
+
+2.2.  Using JWTs for Client Authentication
+
+   To use a JWT Bearer Token for client authentication, the client uses
+   the following parameter values and encodings.
+
+   The value of the "client_assertion_type" is
+   "urn:ietf:params:oauth:client-assertion-type:jwt-bearer".
+
+   The value of the "client_assertion" parameter contains a single JWT.
+   It MUST NOT contain more than one JWT.
+
+   The following example demonstrates client authentication using a JWT
+   during the presentation of an authorization code grant in an access
+   token request (with extra line breaks for display purposes only):
+
+     POST /token.oauth2 HTTP/1.1
+     Host: as.example.com
+     Content-Type: application/x-www-form-urlencoded
+
+     grant_type=authorization_code&
+     code=n0esc3NRze7LTCu7iYzS6a5acc3f0ogp4&
+     client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3A
+     client-assertion-type%3Ajwt-bearer&
+     client_assertion=eyJhbGciOiJSUzI1NiIsImtpZCI6IjIyIn0.
+     eyJpc3Mi[...omitted for brevity...].
+     cC4hiUPo[...omitted for brevity...]
+
+3.  JWT Format and Processing Requirements
+
+   In order to issue an access token response as described in OAuth 2.0
+   [RFC6749] or to rely on a JWT for client authentication, the
+   authorization server MUST validate the JWT according to the criteria
+   below.  Application of additional restrictions and policy are at the
+   discretion of the authorization server.
+
+
+
+
+Jones, et al.                Standards Track                    [Page 5]
+
+RFC 7523              OAuth JWT Assertion Profiles              May 2015
+
+
+   1.   The JWT MUST contain an "iss" (issuer) claim that contains a
+        unique identifier for the entity that issued the JWT.  In the
+        absence of an application profile specifying otherwise,
+        compliant applications MUST compare issuer values using the
+        Simple String Comparison method defined in Section 6.2.1 of RFC
+        3986 [RFC3986].
+
+   2.   The JWT MUST contain a "sub" (subject) claim identifying the
+        principal that is the subject of the JWT.  Two cases need to be
+        differentiated:
+
+        A.  For the authorization grant, the subject typically
+            identifies an authorized accessor for which the access token
+            is being requested (i.e., the resource owner or an
+            authorized delegate), but in some cases, may be a
+            pseudonymous identifier or other value denoting an anonymous
+            user.
+
+        B.  For client authentication, the subject MUST be the
+            "client_id" of the OAuth client.
+
+   3.   The JWT MUST contain an "aud" (audience) claim containing a
+        value that identifies the authorization server as an intended
+        audience.  The token endpoint URL of the authorization server
+        MAY be used as a value for an "aud" element to identify the
+        authorization server as an intended audience of the JWT.  The
+        authorization server MUST reject any JWT that does not contain
+        its own identity as the intended audience.  In the absence of an
+        application profile specifying otherwise, compliant applications
+        MUST compare the audience values using the Simple String
+        Comparison method defined in Section 6.2.1 of RFC 3986
+        [RFC3986].  As noted in Section 5, the precise strings to be
+        used as the audience for a given authorization server must be
+        configured out of band by the authorization server and the
+        issuer of the JWT.
+
+   4.   The JWT MUST contain an "exp" (expiration time) claim that
+        limits the time window during which the JWT can be used.  The
+        authorization server MUST reject any JWT with an expiration time
+        that has passed, subject to allowable clock skew between
+        systems.  Note that the authorization server may reject JWTs
+        with an "exp" claim value that is unreasonably far in the
+        future.
+
+   5.   The JWT MAY contain an "nbf" (not before) claim that identifies
+        the time before which the token MUST NOT be accepted for
+        processing.
+
+
+
+
+Jones, et al.                Standards Track                    [Page 6]
+
+RFC 7523              OAuth JWT Assertion Profiles              May 2015
+
+
+   6.   The JWT MAY contain an "iat" (issued at) claim that identifies
+        the time at which the JWT was issued.  Note that the
+        authorization server may reject JWTs with an "iat" claim value
+        that is unreasonably far in the past.
+
+   7.   The JWT MAY contain a "jti" (JWT ID) claim that provides a
+        unique identifier for the token.  The authorization server MAY
+        ensure that JWTs are not replayed by maintaining the set of used
+        "jti" values for the length of time for which the JWT would be
+        considered valid based on the applicable "exp" instant.
+
+   8.   The JWT MAY contain other claims.
+
+   9.   The JWT MUST be digitally signed or have a Message
+        Authentication Code (MAC) applied by the issuer.  The
+        authorization server MUST reject JWTs with an invalid signature
+        or MAC.
+
+   10.  The authorization server MUST reject a JWT that is not valid in
+        all other respects per "JSON Web Token (JWT)" [JWT].
+
+3.1.  Authorization Grant Processing
+
+   JWT authorization grants may be used with or without client
+   authentication or identification.  Whether or not client
+   authentication is needed in conjunction with a JWT authorization
+   grant, as well as the supported types of client authentication, are
+   policy decisions at the discretion of the authorization server.
+   However, if client credentials are present in the request, the
+   authorization server MUST validate them.
+
+   If the JWT is not valid, or the current time is not within the
+   token's valid time window for use, the authorization server
+   constructs an error response as defined in OAuth 2.0 [RFC6749].  The
+   value of the "error" parameter MUST be the "invalid_grant" error
+   code.  The authorization server MAY include additional information
+   regarding the reasons the JWT was considered invalid using the
+   "error_description" or "error_uri" parameters.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Jones, et al.                Standards Track                    [Page 7]
+
+RFC 7523              OAuth JWT Assertion Profiles              May 2015
+
+
+   For example:
+
+     HTTP/1.1 400 Bad Request
+     Content-Type: application/json
+     Cache-Control: no-store
+
+     {
+      "error":"invalid_grant",
+      "error_description":"Audience validation failed"
+     }
+
+3.2.  Client Authentication Processing
+
+   If the client JWT is not valid, the authorization server constructs
+   an error response as defined in OAuth 2.0 [RFC6749].  The value of
+   the "error" parameter MUST be the "invalid_client" error code.  The
+   authorization server MAY include additional information regarding the
+   reasons the JWT was considered invalid using the "error_description"
+   or "error_uri" parameters.
+
+4.  Authorization Grant Example
+
+   The following examples illustrate what a conforming JWT and an access
+   token request would look like.
+
+   The example shows a JWT issued and signed by the system entity
+   identified as "https://jwt-idp.example.com".  The subject of the JWT
+   is identified by email address as "mike@example.com".  The intended
+   audience of the JWT is "https://jwt-rp.example.net", which is an
+   identifier with which the authorization server identifies itself.
+   The JWT is sent as part of an access token request to the
+   authorization server's token endpoint at "https://authz.example.net/
+   token.oauth2".
+
+   Below is an example JSON object that could be encoded to produce the
+   JWT Claims Set for a JWT:
+
+     {"iss":"https://jwt-idp.example.com",
+      "sub":"mailto:mike@example.com",
+      "aud":"https://jwt-rp.example.net",
+      "nbf":1300815780,
+      "exp":1300819380,
+      "http://claims.example.com/member":true}
+
+   The following example JSON object, used as the header of a JWT,
+   declares that the JWT is signed with the Elliptic Curve Digital
+   Signature Algorithm (ECDSA) P-256 SHA-256 using a key identified by
+   the "kid" value "16".
+
+
+
+Jones, et al.                Standards Track                    [Page 8]
+
+RFC 7523              OAuth JWT Assertion Profiles              May 2015
+
+
+     {"alg":"ES256","kid":"16"}
+
+   To present the JWT with the claims and header shown in the previous
+   example as part of an access token request, for example, the client
+   might make the following HTTPS request (with extra line breaks for
+   display purposes only):
+
+     POST /token.oauth2 HTTP/1.1
+     Host: authz.example.net
+     Content-Type: application/x-www-form-urlencoded
+
+     grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer
+     &assertion=eyJhbGciOiJFUzI1NiIsImtpZCI6IjE2In0.
+     eyJpc3Mi[...omitted for brevity...].
+     J9l-ZhwP[...omitted for brevity...]
+
+5.  Interoperability Considerations
+
+   Agreement between system entities regarding identifiers, keys, and
+   endpoints is required in order to achieve interoperable deployments
+   of this profile.  Specific items that require agreement are as
+   follows: values for the issuer and audience identifiers, the location
+   of the token endpoint, the key used to apply and verify the digital
+   signature or MAC over the JWT, one-time use restrictions on the JWT,
+   maximum JWT lifetime allowed, and the specific subject and claim
+   requirements of the JWT.  The exchange of such information is
+   explicitly out of scope for this specification.  In some cases,
+   additional profiles may be created that constrain or prescribe these
+   values or specify how they are to be exchanged.  Examples of such
+   profiles include the OAuth 2.0 Dynamic Client Registration Core
+   Protocol [OAUTH-DYN-REG], OpenID Connect Dynamic Client Registration
+   1.0 [OpenID.Registration], and OpenID Connect Discovery 1.0
+   [OpenID.Discovery].
+
+   The "RS256" algorithm, from [JWA], is a mandatory-to-implement JSON
+   Web Signature algorithm for this profile.
+
+6.  Security Considerations
+
+   The security considerations described within the following
+   specifications are all applicable to this document: "Assertion
+   Framework for OAuth 2.0 Client Authentication and Authorization
+   Grants" [RFC7521], "The OAuth 2.0 Authorization Framework" [RFC6749],
+   and "JSON Web Token (JWT)" [JWT].
+
+
+
+
+
+
+
+Jones, et al.                Standards Track                    [Page 9]
+
+RFC 7523              OAuth JWT Assertion Profiles              May 2015
+
+
+   The specification does not mandate replay protection for the JWT
+   usage for either the authorization grant or for client
+   authentication.  It is an optional feature, which implementations may
+   employ at their own discretion.
+
+7.  Privacy Considerations
+
+   A JWT may contain privacy-sensitive information and, to prevent
+   disclosure of such information to unintended parties, should only be
+   transmitted over encrypted channels, such as Transport Layer Security
+   (TLS).  In cases where it is desirable to prevent disclosure of
+   certain information to the client, the JWT should be encrypted to the
+   authorization server.
+
+   Deployments should determine the minimum amount of information
+   necessary to complete the exchange and include only such claims in
+   the JWT.  In some cases, the "sub" (subject) claim can be a value
+   representing an anonymous or pseudonymous user, as described in
+   Section 6.3.1 of the OAuth Assertion Framework [RFC7521].
+
+8.  IANA Considerations
+
+8.1.  Sub-Namespace Registration of
+      urn:ietf:params:oauth:grant-type:jwt-bearer
+
+   This section registers the value "grant-type:jwt-bearer" in the IANA
+   "OAuth URI" registry established by "An IETF URN Sub-Namespace for
+   OAuth" [RFC6755].
+
+   o  URN: urn:ietf:params:oauth:grant-type:jwt-bearer
+   o  Common Name: JWT Bearer Token Grant Type Profile for OAuth 2.0
+   o  Change Controller: IESG
+   o  Specification Document: RFC 7523
+
+8.2.  Sub-Namespace Registration of
+      urn:ietf:params:oauth:client-assertion-type:jwt-bearer
+
+   This section registers the value "client-assertion-type:jwt-bearer"
+   in the IANA "OAuth URI" registry established by "An IETF URN Sub-
+   Namespace for OAuth" [RFC6755].
+
+   o  URN: urn:ietf:params:oauth:client-assertion-type:jwt-bearer
+   o  Common Name: JWT Bearer Token Profile for OAuth 2.0 Client
+      Authentication
+   o  Change Controller: IESG
+   o  Specification Document: RFC 7523
+
+
+
+
+
+Jones, et al.                Standards Track                   [Page 10]
+
+RFC 7523              OAuth JWT Assertion Profiles              May 2015
+
+
+9.  References
+
+9.1.  Normative References
+
+   [JWA]      Jones, M., "JSON Web Algorithms (JWA)", RFC 7518,
+              DOI 10.17487/RFC7518, May 2015,
+              <http://www.rfc-editor.org/info/rfc7518>.
+
+   [JWT]      Jones, M., Bradley, J., and N. Sakimura, "JSON Web Token
+              (JWT)", RFC 7519, DOI 10.17487/RFC7519, May 2015,
+              <http://www.rfc-editor.org/info/rfc7519>.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <http://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC3986]  Berners-Lee, T., Fielding, R., and L. Masinter, "Uniform
+              Resource Identifier (URI): Generic Syntax", STD 66,
+              RFC 3986, DOI 10.17487/RFC3986, January 2005,
+              <http://www.rfc-editor.org/info/rfc3986>.
+
+   [RFC6749]  Hardt, D., Ed., "The OAuth 2.0 Authorization Framework",
+              RFC 6749, DOI 10.17487/RFC6749, October 2012,
+              <http://www.rfc-editor.org/info/rfc6749>.
+
+   [RFC7159]  Bray, T., Ed., "The JavaScript Object Notation (JSON) Data
+              Interchange Format", RFC 7159, DOI 10.17487/RFC7159, March
+              2014, <http://www.rfc-editor.org/info/rfc7159>.
+
+   [RFC7521]  Campbell, B., Mortimore, C., Jones, M., and Y. Goland,
+              "Assertion Framework for OAuth 2.0 Client Authentication
+              and Authorization Grants", RFC 7521, DOI 10.17487/RFC7521,
+              May 2015, <http://www.rfc-editor.org/info/rfc7521>.
+
+9.2.  Informative References
+
+   [OAUTH-DYN-REG]
+              Richer, J., Jones, M., Bradley, J., Machulak, M., and P.
+              Hunt, "OAuth 2.0 Dynamic Client Registration Protocol",
+              Work in Progress, draft-ietf-oauth-dyn-reg-29, May 2015.
+
+   [OpenID.Discovery]
+              Sakimura, N., Bradley, J., Jones, M., and E. Jay, "OpenID
+              Connect Discovery 1.0 incorporating errata set 1",
+              November 2014, <http://openid.net/specs/
+              openid-connect-discovery-1_0.html>.
+
+
+
+
+Jones, et al.                Standards Track                   [Page 11]
+
+RFC 7523              OAuth JWT Assertion Profiles              May 2015
+
+
+   [OpenID.Registration]
+              Sakimura, N., Bradley, J., and M. Jones, "OpenID Connect
+              Dynamic Client Registration 1.0 incorporating errata set
+              1", November 2014, <http://openid.net/specs/
+              openid-connect-registration-1_0.html>.
+
+   [RFC6755]  Campbell, B. and H. Tschofenig, "An IETF URN Sub-Namespace
+              for OAuth", RFC 6755, DOI 10.17487/RFC6755, October 2012,
+              <http://www.rfc-editor.org/info/rfc6755>.
+
+   [RFC7522]  Campbell, B., Mortimore, C., and M. Jones, "Security
+              Assertion Markup Language (SAML) 2.0 Profile for OAuth 2.0
+              Client Authentication and Authorization Grants", RFC 7522,
+              DOI 10.17487/RFC7522, May 2015,
+              <http://www.rfc-editor.org/info/rfc7522>.
+
+Acknowledgements
+
+   This profile was derived from "Security Assertion Markup Language
+   (SAML) 2.0 Profile for OAuth 2.0 Client Authentication and
+   Authorization Grants" [RFC7522], which has the same authors as this
+   document.
+
+Authors' Addresses
+
+   Michael B. Jones
+   Microsoft
+
+   EMail: mbj@microsoft.com
+   URI:   http://self-issued.info/
+
+
+   Brian Campbell
+   Ping Identity
+
+   EMail: brian.d.campbell@gmail.com
+
+
+   Chuck Mortimore
+   Salesforce
+
+   EMail: cmortimore@salesforce.com
+
+
+
+
+
+
+
+
+
+Jones, et al.                Standards Track                   [Page 12]
+

--- a/reauth/factors/oauth2/oidc.py
+++ b/reauth/factors/oauth2/oidc.py
@@ -30,9 +30,8 @@ def build_client_assertion(
     *,
     client_id: str,
     token_endpoint: str,
-    key: str,
-    algorithm: str = "RS256",
-    kid: str | None = None,
+    jwks: jwt.PyJWKSet,
+    kid: str,
     lifetime: int = 60,
 ) -> str:
     """Build a signed client assertion JWT for `private_key_jwt` authentication.
@@ -41,17 +40,29 @@ def build_client_assertion(
     client proves its identity to the token endpoint with a short-lived JWT signed
     by its private key, instead of sending a shared secret.
 
+    The signing key is selected from `jwks` by `kid` and advertised in the JOSE
+    header, as required for verification against a multi-key JWKS (OIDC Core
+    §10.1). The signing algorithm is taken from the key itself.
+
     Args:
         client_id: The OAuth2 client identifier, used as both `iss` and `sub`.
         token_endpoint: The token endpoint URL, used as the `aud`.
-        key: The private key to sign with (PEM), as accepted by `jwt.encode`.
-        algorithm: The signing algorithm (e.g. `RS256`, `ES256`).
-        kid: The key ID to advertise in the JWT header, matching the public JWKS.
+        jwks: The client's private JWK Set; the counterpart of the public keys
+            published at its `jwks_uri`.
+        kid: The ID of the key in `jwks` to sign with.
         lifetime: The assertion validity in seconds.
 
     Returns:
         The signed client assertion JWT.
+
+    Raises:
+        SigningKeyNotFoundException: If `kid` is not present in `jwks`.
     """
+    try:
+        signing_key = jwks[kid]
+    except KeyError as e:
+        raise SigningKeyNotFoundException(kid) from e
+
     issued_at = get_current_timestamp()
     return jwt.encode(
         {
@@ -62,9 +73,9 @@ def build_client_assertion(
             "iat": issued_at,
             "exp": issued_at + lifetime,
         },
-        key,
-        algorithm=algorithm,
-        headers={"kid": kid} if kid is not None else None,
+        signing_key.key,
+        algorithm=signing_key.algorithm_name,
+        headers={"kid": signing_key.key_id},
     )
 
 
@@ -82,6 +93,14 @@ class JWKSFetchException(OIDCException):
 
 class InvalidIDTokenException(OIDCException):
     """Raised when an ID Token fails validation."""
+
+
+class SigningKeyNotFoundException(OIDCException):
+    """Raised when the configured signing key ID is not present in the JWKS."""
+
+    def __init__(self, kid: str) -> None:
+        self.kid = kid
+        super().__init__(f"No key with kid '{kid}' in the provided JWKS.")
 
 
 def _validate_id_token_signature(
@@ -621,9 +640,11 @@ class OIDCFactor(OIDCFactorBase):
 class PrivateKeyJWTOIDCFactor(OIDCFactorBase):
     """OpenID Connect factor authenticating with `private_key_jwt` (RFC 7523).
 
-    Signs a short-lived client assertion JWT with the provided private key for
-    each token exchange, instead of sending a shared client secret. The matching
-    public key must be registered with the provider (usually via a JWKS URL).
+    Signs a short-lived client assertion JWT for each token exchange with the key
+    selected from `jwks` by `kid`, instead of sending a shared client secret. The
+    matching public key must be registered with the provider (usually via a JWKS
+    URL). Rotating keys is a matter of adding the new key to `jwks` and pointing
+    `kid` at it (OIDC Core §10.1.1).
 
     The provider must advertise `private_key_jwt` in its
     `token_endpoint_auth_methods_supported`.
@@ -634,10 +655,9 @@ class PrivateKeyJWTOIDCFactor(OIDCFactorBase):
         *,
         identifier: str,
         client_id: str,
-        signing_key: str,
+        jwks: jwt.PyJWKSet,
+        kid: str,
         state_service: OAuth2StateService,
-        algorithm: str = "RS256",
-        kid: str | None = None,
         assertion_lifetime: int = 60,
         step: int = 0,
     ) -> None:
@@ -647,8 +667,7 @@ class PrivateKeyJWTOIDCFactor(OIDCFactorBase):
             state_service=state_service,
             step=step,
         )
-        self._signing_key = signing_key
-        self._algorithm = algorithm
+        self._signing_jwks = jwks
         self._kid = kid
         self._assertion_lifetime = assertion_lifetime
 
@@ -658,8 +677,7 @@ class PrivateKeyJWTOIDCFactor(OIDCFactorBase):
         assertion = build_client_assertion(
             client_id=self.client_id,
             token_endpoint=token_endpoint,
-            key=self._signing_key,
-            algorithm=self._algorithm,
+            jwks=self._signing_jwks,
             kid=self._kid,
             lifetime=self._assertion_lifetime,
         )

--- a/reauth/factors/oauth2/oidc.py
+++ b/reauth/factors/oauth2/oidc.py
@@ -1,6 +1,7 @@
 import abc
 import base64
 import hmac
+import secrets
 import typing
 import urllib.parse
 
@@ -21,6 +22,50 @@ from reauth.logging import get_logger
 from reauth.timestamp import get_current_timestamp
 
 logger = get_logger(__name__)
+
+CLIENT_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+
+
+def build_client_assertion(
+    *,
+    client_id: str,
+    token_endpoint: str,
+    key: str,
+    algorithm: str = "RS256",
+    kid: str | None = None,
+    lifetime: int = 60,
+) -> str:
+    """Build a signed client assertion JWT for `private_key_jwt` authentication.
+
+    Implements the JWT profile for OAuth2 client authentication (RFC 7523): the
+    client proves its identity to the token endpoint with a short-lived JWT signed
+    by its private key, instead of sending a shared secret.
+
+    Args:
+        client_id: The OAuth2 client identifier, used as both `iss` and `sub`.
+        token_endpoint: The token endpoint URL, used as the `aud`.
+        key: The private key to sign with (PEM), as accepted by `jwt.encode`.
+        algorithm: The signing algorithm (e.g. `RS256`, `ES256`).
+        kid: The key ID to advertise in the JWT header, matching the public JWKS.
+        lifetime: The assertion validity in seconds.
+
+    Returns:
+        The signed client assertion JWT.
+    """
+    issued_at = get_current_timestamp()
+    return jwt.encode(
+        {
+            "iss": client_id,
+            "sub": client_id,
+            "aud": token_endpoint,
+            "jti": secrets.token_urlsafe(32),
+            "iat": issued_at,
+            "exp": issued_at + lifetime,
+        },
+        key,
+        algorithm=algorithm,
+        headers={"kid": kid} if kid is not None else None,
+    )
 
 
 class OIDCException(OAuth2Exception):
@@ -571,3 +616,55 @@ class OIDCFactor(OIDCFactorBase):
             f"{self.client_id}:{self._client_secret}".encode()
         ).decode()
         return {"Authorization": f"Basic {credentials}"}, {}
+
+
+class PrivateKeyJWTOIDCFactor(OIDCFactorBase):
+    """OpenID Connect factor authenticating with `private_key_jwt` (RFC 7523).
+
+    Signs a short-lived client assertion JWT with the provided private key for
+    each token exchange, instead of sending a shared client secret. The matching
+    public key must be registered with the provider (usually via a JWKS URL).
+
+    The provider must advertise `private_key_jwt` in its
+    `token_endpoint_auth_methods_supported`.
+    """
+
+    def __init__(
+        self,
+        *,
+        identifier: str,
+        client_id: str,
+        signing_key: str,
+        state_service: OAuth2StateService,
+        algorithm: str = "RS256",
+        kid: str | None = None,
+        assertion_lifetime: int = 60,
+        step: int = 0,
+    ) -> None:
+        super().__init__(
+            identifier=identifier,
+            client_id=client_id,
+            state_service=state_service,
+            step=step,
+        )
+        self._signing_key = signing_key
+        self._algorithm = algorithm
+        self._kid = kid
+        self._assertion_lifetime = assertion_lifetime
+
+    async def get_request_authentication(
+        self, *, token_endpoint: str
+    ) -> tuple[dict[str, str], dict[str, str]]:
+        assertion = build_client_assertion(
+            client_id=self.client_id,
+            token_endpoint=token_endpoint,
+            key=self._signing_key,
+            algorithm=self._algorithm,
+            kid=self._kid,
+            lifetime=self._assertion_lifetime,
+        )
+        return {}, {
+            "client_id": self.client_id,
+            "client_assertion_type": CLIENT_ASSERTION_TYPE,
+            "client_assertion": assertion,
+        }

--- a/tests/factors/oauth2/test_oidc.py
+++ b/tests/factors/oauth2/test_oidc.py
@@ -6,7 +6,7 @@ import urllib.parse
 import httpx
 import jwt
 import pytest
-from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 from sqlalchemy.ext.asyncio import AsyncConnection
@@ -28,6 +28,7 @@ from reauth.factors.oauth2.oidc import (
     JWKSFetchException,
     OIDCFactor,
     PrivateKeyJWTOIDCFactor,
+    SigningKeyNotFoundException,
     validate_id_token,
 )
 from reauth.factors.oauth2.state import OAuth2State
@@ -47,6 +48,15 @@ def get_jwks_from_rsa_key(key: RSAPrivateKey, kid: str) -> jwt.PyJWKSet:
         "kid": kid,
     }
     return jwt.PyJWKSet.from_dict({"keys": [public_jwk]})
+
+
+def get_private_jwks_from_rsa_key(key: RSAPrivateKey, kid: str) -> jwt.PyJWKSet:
+    algorithm = jwt.get_algorithm_by_name("RS256")
+    private_jwk = {
+        **algorithm.to_jwk(key, as_dict=True),
+        "kid": kid,
+    }
+    return jwt.PyJWKSet.from_dict({"keys": [private_jwk]})
 
 
 def create_id_token(
@@ -671,15 +681,11 @@ class TestPrivateKeyJWTOIDCFactorGetRequestAuthentication:
         rsa_key: RSAPrivateKey,
     ) -> None:
         """private_key_jwt sends a signed JWT assertion in the request body."""
-        signing_key = rsa_key.private_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PrivateFormat.PKCS8,
-            encryption_algorithm=serialization.NoEncryption(),
-        ).decode()
         factor = _PrivateKeyJWTFactor(
             identifier="oidc",
             client_id="test-client-id",
-            signing_key=signing_key,
+            jwks=get_private_jwks_from_rsa_key(rsa_key, "sign-key-1"),
+            kid="sign-key-1",
             state_service=oauth2_state_service,
         )
 
@@ -690,6 +696,9 @@ class TestPrivateKeyJWTOIDCFactorGetRequestAuthentication:
         assert headers == {}
         assert body["client_id"] == "test-client-id"
         assert body["client_assertion_type"] == CLIENT_ASSERTION_TYPE
+        assert (
+            jwt.get_unverified_header(body["client_assertion"])["kid"] == "sign-key-1"
+        )
         claims = jwt.decode(
             body["client_assertion"],
             rsa_key.public_key(),
@@ -698,3 +707,20 @@ class TestPrivateKeyJWTOIDCFactorGetRequestAuthentication:
         )
         assert claims["iss"] == "test-client-id"
         assert claims["sub"] == "test-client-id"
+
+    async def test_raises_when_kid_not_in_jwks(
+        self,
+        oauth2_state_service: SQLAlchemyOAuth2StateService,
+        rsa_key: RSAPrivateKey,
+    ) -> None:
+        """An unknown signing key id is surfaced as an OIDCException."""
+        factor = _PrivateKeyJWTFactor(
+            identifier="oidc",
+            client_id="test-client-id",
+            jwks=get_private_jwks_from_rsa_key(rsa_key, "sign-key-1"),
+            kid="unknown-key",
+            state_service=oauth2_state_service,
+        )
+
+        with pytest.raises(SigningKeyNotFoundException):
+            await factor.get_request_authentication(token_endpoint=TOKEN_ENDPOINT)

--- a/tests/factors/oauth2/test_oidc.py
+++ b/tests/factors/oauth2/test_oidc.py
@@ -6,7 +6,7 @@ import urllib.parse
 import httpx
 import jwt
 import pytest
-from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 from sqlalchemy.ext.asyncio import AsyncConnection
@@ -22,10 +22,12 @@ from reauth.factors.oauth2.base import (
     OAuth2TokenUnsupportedGrantTypeException,
 )
 from reauth.factors.oauth2.oidc import (
+    CLIENT_ASSERTION_TYPE,
     DiscoveryDocumentException,
     InvalidIDTokenException,
     JWKSFetchException,
     OIDCFactor,
+    PrivateKeyJWTOIDCFactor,
     validate_id_token,
 )
 from reauth.factors.oauth2.state import OAuth2State
@@ -639,3 +641,60 @@ class TestOIDCFactorExchangeCode:
                 redirect_uri="https://example.com/callback",
                 state=oauth2_state,
             )
+
+
+class _PrivateKeyJWTFactor(PrivateKeyJWTOIDCFactor):
+    DISCOVERY_ENDPOINT = DISCOVERY_ENDPOINT
+
+    async def insert(self, enrollment: OAuth2Enrollment) -> int:
+        raise NotImplementedError()
+
+    async def update(self, enrollment: OAuth2Enrollment) -> None:
+        raise NotImplementedError()
+
+    async def get_enrollment(self, identity_id: int) -> OAuth2Enrollment | None:
+        raise NotImplementedError()
+
+    async def get_enrollment_by_provider_and_account(
+        self, provider: str, account_id: str
+    ) -> OAuth2Enrollment | None:
+        raise NotImplementedError()
+
+
+@pytest.mark.anyio
+class TestPrivateKeyJWTOIDCFactorGetRequestAuthentication:
+    """Tests for PrivateKeyJWTOIDCFactor.get_request_authentication()."""
+
+    async def test_returns_signed_client_assertion_in_body(
+        self,
+        oauth2_state_service: SQLAlchemyOAuth2StateService,
+        rsa_key: RSAPrivateKey,
+    ) -> None:
+        """private_key_jwt sends a signed JWT assertion in the request body."""
+        signing_key = rsa_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ).decode()
+        factor = _PrivateKeyJWTFactor(
+            identifier="oidc",
+            client_id="test-client-id",
+            signing_key=signing_key,
+            state_service=oauth2_state_service,
+        )
+
+        headers, body = await factor.get_request_authentication(
+            token_endpoint=TOKEN_ENDPOINT
+        )
+
+        assert headers == {}
+        assert body["client_id"] == "test-client-id"
+        assert body["client_assertion_type"] == CLIENT_ASSERTION_TYPE
+        claims = jwt.decode(
+            body["client_assertion"],
+            rsa_key.public_key(),
+            algorithms=["RS256"],
+            audience=TOKEN_ENDPOINT,
+        )
+        assert claims["iss"] == "test-client-id"
+        assert claims["sub"] == "test-client-id"


### PR DESCRIPTION
Adds a `private_key_jwt` OIDC factor that authenticates token requests with a short-lived, asymmetrically-signed client assertion JWT ([RFC 7523]) instead of a shared `client_secret`.